### PR TITLE
support for chrome devtools _initiator attributes 'type', 'url' and 'lineNumber'

### DIFF
--- a/src/Entry.php
+++ b/src/Entry.php
@@ -78,6 +78,14 @@ final class Entry
      */
     private $connection;
 
+    /**
+     * Detailed info about the request.
+     *
+     * @var \Deviantintegral\Har\Initiator
+     * @Serializer\Type("Deviantintegral\Har\Initiator")
+     */
+    private $_initiator;
+
     public function getPageref(): string
     {
         return $this->pageref;
@@ -214,6 +222,26 @@ final class Entry
     public function setConnection(string $connection): self
     {
         $this->connection = $connection;
+
+        return $this;
+    }
+
+    public function getInitiator(): ?Initiator
+    {
+        return $this->_initiator;
+    }
+
+    public function hasInitiator(): bool
+    {
+        return null !== $this->_initiator;
+    }
+
+    /**
+     * @return Entry
+     */
+    public function setInitiator(Initiator $_initiator): self
+    {
+        $this->_initiator = $_initiator;
 
         return $this;
     }

--- a/src/Initiator.php
+++ b/src/Initiator.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace Deviantintegral\Har;
+
+use JMS\Serializer\Annotation as Serializer;
+
+/**
+ * @see https://developers.google.com/web/tools/chrome-devtools/network/reference#requests
+ */
+final class Initiator
+{
+    /**
+     * @var string
+     * @Serializer\Type("string")
+     *
+     * parser:
+     *   Chrome's HTML parser.
+     * redirect:
+     *   An HTTP redirect.
+     * script:
+     *   A JavaScript function.
+     * other:
+     *   Some other process or action, such as navigating to a page via a link
+     *   or entering a URL in the address bar.
+     */
+    private $type;
+
+    /**
+     * URL of the entry that initiated this request.
+     *
+     * @var \Psr\Http\Message\UriInterface
+     * @Serializer\Type("Psr\Http\Message\UriInterface")
+     */
+    private $url;
+
+    /**
+     * Line number that initiated this request.
+     *
+     * @var int
+     * @Serializer\Type("integer")
+     */
+    private $lineNumber;
+
+    public function getType(): ?string
+    {
+        return $this->type;
+    }
+
+    /**
+     * @return Initiator
+     */
+    public function setType(string $type): self
+    {
+        $this->type = $type;
+
+        return $this;
+    }
+
+    public function getUrl(): ?\Psr\Http\Message\UriInterface
+    {
+        return $this->url;
+    }
+
+    public function hasUrl(): bool
+    {
+        return null !== $this->url;
+    }
+
+    /**
+     * @return Initiator
+     */
+    public function setUrl(\Psr\Http\Message\UriInterface $url): self
+    {
+        $this->url = $url;
+
+        return $this;
+    }
+
+    public function getLineNumber(): ?int
+    {
+        return $this->lineNumber;
+    }
+
+    public function hasLineNumber(): bool
+    {
+        return null !== $this->lineNumber;
+    }
+
+    /**
+     * @return Initiator
+     */
+    public function setLineNumber(int $lineNumber): self
+    {
+        $this->lineNumber = $lineNumber;
+
+        return $this;
+    }
+}

--- a/tests/src/Unit/EntryTest.php
+++ b/tests/src/Unit/EntryTest.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Deviantintegral\Har\Tests\Unit;
+
+use Deviantintegral\Har\Initiator;
+use Deviantintegral\Har\Repository\HarFileRepository;
+
+/**
+ * @covers \Deviantintegral\Har\Entry
+ */
+class EntryTest extends HarTestBase
+{
+    private $repository;
+
+    protected function setUp(): void
+    {
+        // Initialize a repository of HAR files, with IDs being the file names.
+        $this->repository = new HarFileRepository(__DIR__.'/../../fixtures');
+    }
+
+    public function testHasInitiator()
+    {
+        // Load a HAR file into an object.
+        $har = $this->repository->load('www.softwareishard.com-empty-login.har');
+        $first = $har->getLog()->getEntries()[0];
+        $this->assertFalse($first->hasInitiator());
+        $first->setInitiator((new Initiator())->setType('other'));
+        $this->assertTrue($first->hasInitiator());
+    }
+
+    public function testSerializationOfEntryWithAddedInitiatorOfTypeOther()
+    {
+        // Load a HAR file into an object.
+        $id = 'www.softwareishard.com-empty-login.har';
+        $har = $this->repository->load($id);
+        $first = $har->getLog()->getEntries()[0];
+        $first->setInitiator((new Initiator())->setType('other'));
+
+        $serialized = $this->getSerializer()->serialize($har, 'json');
+        $actual = json_decode($serialized, true);
+        $this->assertIsArray($actual['log']['entries'][0]['_initiator']);
+        $this->assertEquals('other', $actual['log']['entries'][0]['_initiator']['type']);
+        $this->assertArrayNotHasKey('url', $actual['log']['entries'][0]['_initiator']);
+        $this->assertArrayNotHasKey('lineNumber', $actual['log']['entries'][0]['_initiator']);
+
+        $this->assertArrayNotHasKey('_initiator', $actual['log']['entries'][1]);
+    }
+}

--- a/tests/src/Unit/InitiatorTest.php
+++ b/tests/src/Unit/InitiatorTest.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Deviantintegral\Har\Tests\Unit;
+
+use Deviantintegral\Har\Initiator;
+use GuzzleHttp\Psr7\Uri;
+
+/**
+ * @covers \Deviantintegral\Har\Initiator
+ */
+class InitiatorTest extends HarTestBase
+{
+    public function testInitiatorWithTypeOther()
+    {
+        $serializer = $this->getSerializer();
+
+        $initiator = (new Initiator())
+            ->setType('other');
+        $serialized = $serializer->serialize($initiator, 'json');
+        $this->assertEquals(
+            ['type' => 'other'],
+            json_decode($serialized, true)
+        );
+
+        $this->assertDeserialize($serialized, Initiator::class, $initiator);
+
+        $this->assertFalse($initiator->hasUrl());
+        $this->assertNull($initiator->getUrl());
+        $this->assertFalse($initiator->hasLineNumber());
+        $this->assertNull($initiator->getLineNumber());
+    }
+
+    public function testInitiatorWithTypeParser()
+    {
+        $serializer = $this->getSerializer();
+
+        $initiator = (new Initiator())
+            ->setType('parser')
+            ->setUrl(new Uri('https://www.php.net/'))
+            ->setLineNumber(42);
+        $serialized = $serializer->serialize($initiator, 'json');
+        $this->assertEquals(
+            [
+                'type' => 'parser',
+                'url' => 'https://www.php.net/',
+                'lineNumber' => '42',
+            ],
+            json_decode($serialized, true)
+        );
+
+        $this->assertDeserialize($serialized, Initiator::class, $initiator);
+        $this->assertTrue($initiator->hasLineNumber());
+        $this->assertIsNumeric($initiator->getLineNumber());
+        $this->assertTrue($initiator->hasUrl());
+        $this->assertNotNull($initiator->getUrl());
+    }
+}


### PR DESCRIPTION
Hi @deviantintegral 
I'm interested also in the non-standard attributes that chrome devtools exports since around chrome 67 or so.

All new APIs should be covered by tests.