### PR TITLE
fix: remove followTag config as it doesn't work with branches

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -35,15 +35,6 @@
   ],
   "packageRules": [
     {
-      "matchManagers": [
-        "github-actions"
-      ],
-      "matchPackageNames": [
-        "deviantintegral/github-action-renovate-config-validator"
-      ],
-      "followTag": "fix-renovate-version"
-    },
-    {
       "minimumReleaseAge": "3 days",
       "automerge": true,
       "matchPackageNames": [


### PR DESCRIPTION
followTag is designed for npm tags, not git branches.

Refs: https://github.com/renovatebot/renovate/issues/28016