### PR TITLE
chore: switch renovate-config-validator to official v2.0.0

### DIFF
--- a/.github/workflows/renovate-config-validator.yml
+++ b/.github/workflows/renovate-config-validator.yml
@@ -14,6 +14,6 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
-      - uses: deviantintegral/github-action-renovate-config-validator@322e333e6885127adce1185bf8a377a3fd053c66 # fix-renovate-version
+      - uses: suzuki-shunsuke/github-action-renovate-config-validator@fda7db3799c8b28652153419da38c22fe8283667 # v2.0.0
         with:
           strict: false


### PR DESCRIPTION
Switch from the deviantintegral fork back to the official suzuki-shunsuke/github-action-renovate-config-validator action now that v2.0.0 has been released with the necessary fixes.