### PR TITLE
feat(renovate): add prCreation and internalChecksFilter options

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -36,6 +36,8 @@
   "packageRules": [
     {
       "minimumReleaseAge": "3 days",
+      "prCreation": "not-pending",
+      "internalChecksFilter": "strict",
       "automerge": true,
       "matchPackageNames": [
         "*"


### PR DESCRIPTION
Add prCreation="not-pending" and internalChecksFilter="strict" to ensure branches and PRs are only created after the minimumReleaseAge has passed.