### PR TITLE
chore(ci): exclude chore commits from release notes

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -22,8 +22,11 @@ jobs:
         id: release
         with:
           token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
-          # This should match the configuration of your conventional commits
-          release-type: php
+          # Configuration, including the release type, lives in
+          # release-please-config.json. Do not pass release-type here: the
+          # action ignores the config file entirely when that input is set.
+          config-file: release-please-config.json
+          manifest-file: .release-please-manifest.json
 
   build-phar:
     name: Build and Upload PHAR

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
+  "release-type": "php",
+  "changelog-sections": [
+    { "type": "feat", "section": "Features" },
+    { "type": "fix", "section": "Bug Fixes" },
+    { "type": "perf", "section": "Performance Improvements" },
+    { "type": "revert", "section": "Reverts" },
+    { "type": "chore", "section": "Miscellaneous Chores", "hidden": true },
+    { "type": "docs", "section": "Documentation", "hidden": true },
+    { "type": "style", "section": "Styles", "hidden": true },
+    { "type": "refactor", "section": "Code Refactoring", "hidden": true },
+    { "type": "test", "section": "Tests", "hidden": true },
+    { "type": "build", "section": "Build System", "hidden": true },
+    { "type": "ci", "section": "Continuous Integration", "hidden": true }
+  ],
+  "packages": {
+    ".": {}
+  }
+}


### PR DESCRIPTION
## Problem

Every release's notes are dominated by Renovate `chore(deps)` bumps under a **Miscellaneous Chores** heading (see `CHANGELOG.md` for 1.1.0 and 1.2.0).

This isn't the conventional-commits default — the preset hides `chore`. release-please's [PHP strategy](https://github.com/googleapis/release-please/blob/main/src/strategies/php.ts) overrides the preset with its own `CHANGELOG_SECTIONS` that lists `chore` without `hidden: true`.

## Fix

- Add `release-please-config.json` with explicit `changelog-sections` matching the PHP strategy's list, but with `chore` marked `hidden: true`. Other types keep their current visibility (`feat`, `fix`, `perf`, `revert` shown; the rest hidden).
- Remove the `release-type: php` input from the workflow and point the action at the config/manifest files instead. This part is required: the action only reads `release-please-config.json` when `release-type` is *not* set — with the input present it builds the manifest from that input alone and the config file is ignored. `release-type` now lives in the config file.

Breaking changes still appear regardless of the hidden flag, so a `chore!:` commit would still be listed.

Verified: config is valid JSON and validates against release-please's published config schema; workflow YAML parses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QnQuB532Y6HLPVJLrQyM9E