### PR TITLE
ci: group guzzle and psr7 renovate updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -43,6 +43,16 @@
       ]
     },
     {
+      "groupName": "guzzle",
+      "matchManagers": [
+        "composer"
+      ],
+      "matchPackageNames": [
+        "guzzlehttp/guzzle",
+        "guzzlehttp/psr7"
+      ]
+    },
+    {
       "matchCurrentVersion": "8.0",
       "matchPackageNames": [
         "php"


### PR DESCRIPTION
Adds a Renovate `packageRules` entry that groups `guzzlehttp/guzzle` and `guzzlehttp/psr7` into a single "guzzle" branch/PR.

These two release majors in lockstep (guzzle 8 requires psr7 3), so separate PRs each fail CI on their own while the combined bump passes. Grouping them means Renovate proposes the upgrade the way it actually has to land.

Validated with `renovate-config-validator`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L6Gt5TWiyknjyZSJpn2eRH