### PR TITLE
feat(deps): drop doctrine/annotations

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,6 @@
         "php": "^8.2",
         "ext-json": "*",
         "jms/serializer": "^3.0",
-        "doctrine/annotations": "^2.0",
         "guzzlehttp/psr7": "^3.0",
         "psr/http-client": "^1.0",
         "deviantintegral/jms-serializer-uri-handler": "^1.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "81425c41e24a952b3431d5be94b5dd3c",
+    "content-hash": "6937b1e5aef930a96a5ba9ef1fac22cf",
     "packages": [
         {
             "name": "deviantintegral/jms-serializer-uri-handler",
@@ -97,83 +97,6 @@
                 "source": "https://github.com/deviantintegral/null-date-time/tree/v1.1.2"
             },
             "time": "2026-04-15T23:48:29+00:00"
-        },
-        {
-            "name": "doctrine/annotations",
-            "version": "2.0.2",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/doctrine/annotations.git",
-                "reference": "901c2ee5d26eb64ff43c47976e114bf00843acf7"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/annotations/zipball/901c2ee5d26eb64ff43c47976e114bf00843acf7",
-                "reference": "901c2ee5d26eb64ff43c47976e114bf00843acf7",
-                "shasum": ""
-            },
-            "require": {
-                "doctrine/lexer": "^2 || ^3",
-                "ext-tokenizer": "*",
-                "php": "^7.2 || ^8.0",
-                "psr/cache": "^1 || ^2 || ^3"
-            },
-            "require-dev": {
-                "doctrine/cache": "^2.0",
-                "doctrine/coding-standard": "^10",
-                "phpstan/phpstan": "^1.10.28",
-                "phpunit/phpunit": "^7.5 || ^8.5 || ^9.5",
-                "symfony/cache": "^5.4 || ^6.4 || ^7",
-                "vimeo/psalm": "^4.30 || ^5.14"
-            },
-            "suggest": {
-                "php": "PHP 8.0 or higher comes with attributes, a native replacement for annotations"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Doctrine\\Common\\Annotations\\": "lib/Doctrine/Common/Annotations"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Guilherme Blanco",
-                    "email": "guilhermeblanco@gmail.com"
-                },
-                {
-                    "name": "Roman Borschel",
-                    "email": "roman@code-factory.org"
-                },
-                {
-                    "name": "Benjamin Eberlei",
-                    "email": "kontakt@beberlei.de"
-                },
-                {
-                    "name": "Jonathan Wage",
-                    "email": "jonwage@gmail.com"
-                },
-                {
-                    "name": "Johannes Schmitt",
-                    "email": "schmittjoh@gmail.com"
-                }
-            ],
-            "description": "Docblock Annotations Parser",
-            "homepage": "https://www.doctrine-project.org/projects/annotations.html",
-            "keywords": [
-                "annotations",
-                "docblock",
-                "parser"
-            ],
-            "support": {
-                "issues": "https://github.com/doctrine/annotations/issues",
-                "source": "https://github.com/doctrine/annotations/tree/2.0.2"
-            },
-            "abandoned": true,
-            "time": "2024-09-05T10:17:24+00:00"
         },
         {
             "name": "doctrine/instantiator",
@@ -652,55 +575,6 @@
                 "source": "https://github.com/phpstan/phpdoc-parser/tree/2.3.3"
             },
             "time": "2026-07-08T07:01:06+00:00"
-        },
-        {
-            "name": "psr/cache",
-            "version": "3.0.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/php-fig/cache.git",
-                "reference": "aa5030cfa5405eccfdcb1083ce040c2cb8d253bf"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/cache/zipball/aa5030cfa5405eccfdcb1083ce040c2cb8d253bf",
-                "reference": "aa5030cfa5405eccfdcb1083ce040c2cb8d253bf",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=8.0.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.0.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Psr\\Cache\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "PHP-FIG",
-                    "homepage": "https://www.php-fig.org/"
-                }
-            ],
-            "description": "Common interface for caching libraries",
-            "keywords": [
-                "cache",
-                "psr",
-                "psr-6"
-            ],
-            "support": {
-                "source": "https://github.com/php-fig/cache/tree/3.0.0"
-            },
-            "time": "2021-02-03T23:26:27+00:00"
         },
         {
             "name": "psr/container",


### PR DESCRIPTION
Removes `doctrine/annotations` from `require`.

## Why it's safe

- **Nothing here uses annotations.** All 69 serializer metadata declarations in `src/` are PHP 8 attributes (`#[Serializer\Type(...)]`, `#[Serializer\PostDeserialize]`, …). There are zero docblock `@Serializer` annotations.
- **JMS doesn't need it on PHP 8.** `DefaultDriverFactory::createDriver()` only throws the "doctrine/annotations must be installed" error when `PHP_VERSION_ID < 80000`. Above that it registers `AnnotationOrAttributeDriver` with a **null** reader, and that driver calls `getAttributes(SerializerAttribute::class, IS_INSTANCEOF)` unconditionally — the reader is only an extra `array_merge` when non-null. This package requires `php: ^8.2`, so that branch is unreachable.
- **Verified by removing it.** Full suite passes with the package absent: 334 tests, 990 assertions. PHPStan clean, PHP-CS-Fixer clean, `composer validate --strict` passes, and `composer install --no-dev` (what the PHAR builds from) resolves.

## Lock impact

The lock diff removes exactly two packages: `doctrine/annotations` and `psr/cache` (its only dependent here). `doctrine/lexer` stays, since `jms/serializer` requires it directly.

This library was the **sole runtime requirer** — `jms/serializer` and `deviantintegral/jms-serializer-uri-handler` both list it under `require-dev`. So this genuinely uninstalls it downstream rather than leaving it behind transitively.

## Compatibility note

No break to this library's own API or behavior. One downstream edge case is worth a release note: `Serializer::getSerializerBuilder()` is public API, so anyone who takes that builder and serializes **their own** docblock-annotated classes will silently lose that metadata (empty metadata via `NullDriver`) rather than get an error. Those consumers should add `doctrine/annotations` to their own `composer.json`.

Typed as `feat` so release-please cuts a minor and the entry is visible in the changelog. Retype to `build`/`chore` if you'd rather it be a hidden patch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013DMMmSMemViyZXtmDwQgvk
